### PR TITLE
check for custom ID_LIKE second-to-last (to detect ubuntu-based)

### DIFF
--- a/lib/plat4m/sniff/linux.rb
+++ b/lib/plat4m/sniff/linux.rb
@@ -39,14 +39,14 @@ module Plat4m
                        hash
                      end
                      {
-                       variant: if File.file?('/etc/redhat-release')
+                       variant: if data['ID_LIKE']
+                                  data['ID_LIKE'].split.first.to_sym
+                                elsif File.file?('/etc/redhat-release')
                                   :rhel
                                 elsif File.file?('/etc/SUSE-brand') || File.file?('/etc/SuSE-release')
                                   :suse
                                 elsif File.file?('/etc/debian_version')
                                   :debian
-                                elsif data['ID_LIKE']
-                                  data['ID_LIKE'].split.first.to_sym
                                 else
                                   data['ID'].to_sym
                                 end,
@@ -78,7 +78,7 @@ module Plat4m
                      }
                    end
           distro[:pkgman] = case distro[:variant]
-                            when :debian
+                            when :debian, :ubuntu
                               Apt.new(distro)
                             when :rhel
                               Dnf.new(distro)

--- a/lib/plat4m/sniff/linux.rb
+++ b/lib/plat4m/sniff/linux.rb
@@ -39,14 +39,14 @@ module Plat4m
                        hash
                      end
                      {
-                       variant: if data['ID_LIKE']
-                                  data['ID_LIKE'].split.first.to_sym
-                                elsif File.file?('/etc/redhat-release')
+                       variant: if File.file?('/etc/redhat-release')
                                   :rhel
                                 elsif File.file?('/etc/SUSE-brand') || File.file?('/etc/SuSE-release')
                                   :suse
                                 elsif File.file?('/etc/debian_version')
                                   :debian
+                                elsif data['ID_LIKE']
+                                  data['ID_LIKE'].split.first.to_sym
                                 else
                                   data['ID'].to_sym
                                 end,


### PR DESCRIPTION
Not sure about other Ubuntu-based distros, but on Linux Mint, in `/etc/os-release` we have
```
ID_LIKE="ubuntu debian"
```
so, `data['ID_LIKE'].split.first.to_sym` will grab `ubuntu`, which is not checked in the case/when on line 80, therefore no `pkgman` will be set.

I discovered this when I ran `wxruby setup` and got
```
ERROR: Do not know how to install required packages for distro type 'ubuntu'.
```

In IRB:
```
irb(main):001> require 'plat4m'
=> true
irb(main):002> Plat4m.current
=> #<Plat4m::System:0x000079b48d88c690 @os=#<Plat4m::System::OS:0x000079b48cd439f0 @distro="linuxmint", @id=:linux, @other={}, @pkgman=nil, @release="22", @variant=:ubuntu>, @platform=#<Plat4m::System::Platform:0x000079b48d88eb70 @arch="x86_64", @bits=64, @cpus=16>>
```
I could have simply added `:ubuntu` to the case/when, but I think it makes more sense to check known filenames first in general, in case there is some other debian-but-not-ubuntu-based distro that puts its signifier in `/etc/os-release`.